### PR TITLE
Have terraform handle known_hosts additions and deletions

### DIFF
--- a/add_to_known_hosts.sh
+++ b/add_to_known_hosts.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+usage()
+{
+    echo "usage: add_to_known_hosts.sh  [[--add hostname ] | [--delete hostname]| [-h]]"
+}
+
+hostname=""
+add=false
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -a | --add )        shift
+                            hostname=$1
+                            add=true
+                            ;;
+        -d | --delete )     shift
+                            hostname=$1
+                            ;;
+        -h | --help )       usage
+                            exit
+                            ;;
+        * )                 usage
+                            exit 1
+    esac
+    shift
+done
+
+if [ "$hostname" = "" ]; then
+    echo "no hostname passed. Exiting.";
+    exit 1;
+fi
+
+# Remove any existing known_hosts entry matching the passed ip or hostname. 
+# This will not catch both. Creates backup in case it's used incorrectly outside of Terraform.
+sed -i.bak "/$hostname/d" ~/.ssh/known_hosts
+
+# Add remote host's public keys to known_hosts
+if $add ; then
+  ssh-keyscan $hostname 2> /dev/null | grep -v '^#' >> ~/.ssh/known_hosts
+fi
+

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,13 +1,13 @@
 ---
-- hosts: all
-  become: yes
-  become_user: root
-  become_method: sudo
-  gather_facts: False
-  tasks:
-  - name: install python 2
-    raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
-    changed_when: False
+# - hosts: all
+#   become: yes
+#   become_user: root
+#   become_method: sudo
+#   gather_facts: False
+#   tasks:
+#   - name: install python 2
+#     raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+#     changed_when: False
 
 - hosts: all
   become: yes

--- a/reference_cluster/ansible.cfg
+++ b/reference_cluster/ansible.cfg
@@ -2,11 +2,12 @@
 inventory = ./inventory/site.yaml
 remote_user = ubuntu
 # Disable retry file creation. If you want to enable have the file save 
-# from the rundir and not in the shared ansible playbook directory.
+# from the rundir and not in the shared Ansible playbook directory.
 retry_files_enabled = False
 retry_files_save_path = ./
+roles_path = ../ansible/roles
 
 [ssh_connection]
-ssh_args = -o StrictHostKeyChecking=no -o ControlPersist=15m -F ssh.config -q
+ssh_args = -o ControlPersist=15m -F ssh.config -q
 scp_if_ssh = True
 control_path = ~/.ssh/mux-%%r@%%h:%%p

--- a/reference_cluster/resources.tf
+++ b/reference_cluster/resources.tf
@@ -34,6 +34,17 @@ resource "ibm_compute_vm_instance" "bastion" {
     ]
   }
 
+  # On create delete conflicting entries in known hosts and add via ssh-keyscan
+  provisioner "local-exec" {
+    command = "../add_to_known_hosts.sh -a ${self.ipv4_address}"
+  }
+
+  # On destroy remove from known hosts
+  provisioner "local-exec" {
+    when = "destroy"
+    command = "../add_to_known_hosts.sh -d ${self.ipv4_address}"
+  }
+
 }
 
 #################################################

--- a/reference_cluster/ssh.config.template
+++ b/reference_cluster/ssh.config.template
@@ -5,8 +5,6 @@ Host bastion
     IdentityFile           REPLACE_WITH_PEM_PATH
     BatchMode              yes
     PasswordAuthentication no
-    UserKnownHostsFile=/dev/null
-    StrictHostKeyChecking=no
 
 Host *
     ServerAliveInterval    60
@@ -17,5 +15,3 @@ Host *
     ControlPersist         8h
     User                   ubuntu
     IdentityFile           REPLACE_WITH_PEM_PATH
-    UserKnownHostsFile=/dev/null
-    StrictHostKeyChecking=no

--- a/setup_terraform.sh
+++ b/setup_terraform.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 os_type=$(uname -s | tr '[:upper:]' '[:lower:]')
+# Cygwin Not actually tested. Feedback from a Cygwin user is welcomed.
 if [[ $os_type == "cygwin"* ]]; then
   os_type="windows"
 fi
@@ -31,7 +32,7 @@ else
   echo "Found Terraform binary in ${tf_dir}, skipping download"
 fi
 
-# Allow for cases where there are multiple ibm provider version in the plugins folder.
+# Allow for cases where there are multiple IBM provider version in the plugins folder.
 ibm_providers=(~/.terraform.d/plugins/terraform-provider-ibm*)
 
 if [ ! -e ${ibm_providers[0]} ]; then


### PR DESCRIPTION
Added shell script to allow terraform to remove and add ssh public keys from known_hosts. Also removed `StrictHostKeyChecking=no` hacks.
Signed-off-by: Chris Hupman <chupman@us.ibm.com>